### PR TITLE
Prevent the changelist causing an exception

### DIFF
--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -2,6 +2,7 @@
 
 import sys
 
+from django.conf import settings
 from django.conf.urls import patterns, url
 
 from django.contrib import admin, messages
@@ -35,6 +36,12 @@ class TreeAdmin(admin.ModelAdmin):
         if issubclass(self.model, AL_Node):
             # For AL trees, use the old admin display
             self.change_list_template = 'admin/tree_list.html'
+        if extra_context is None:
+            extra_context = {}
+        lacks_request = ('request' not in extra_context and
+            'django.core.context_processors.request' not in settings.TEMPLATE_CONTEXT_PROCESSORS)
+        if lacks_request:
+            extra_context['request'] = request
         return super(TreeAdmin, self).changelist_view(request, extra_context)
 
     def get_urls(self):


### PR DESCRIPTION
When the the context processor for inserting `request` into the Context is not present in TEMPLATE_CONTEXT_PROCESSORS, `{% result_tree ... %}` will fail because `request` will resolve to `''` and then will end up doing `AttributeError: 'str' object has no attribute 'path'` when trying to insert data into `headers` (and also when returning)