### PR TITLE
Django1.7: Rename MP_NodeManager.get_query_set to get_queryset

### DIFF
--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -35,7 +35,7 @@ def get_result_class(cls):
 class AL_NodeManager(models.Manager):
     """Custom manager for nodes in an Adjacency List tree."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Sets the custom queryset as the default."""
         if self.model.node_order_by:
             order_by = ['parent'] + list(self.model.node_order_by)

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -102,7 +102,7 @@ class MP_NodeQuerySet(models.query.QuerySet):
 class MP_NodeManager(models.Manager):
     """Custom manager for nodes in a Materialized Path tree."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Sets the custom queryset as the default."""
         return MP_NodeQuerySet(self.model).order_by('path')
 

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -104,7 +104,7 @@ class NS_NodeQuerySet(models.query.QuerySet):
 class NS_NodeManager(models.Manager):
     """Custom manager for nodes in a Nested Sets tree."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Sets the custom queryset as the default."""
         return NS_NodeQuerySet(self.model).order_by('tree_id', 'lft')
 


### PR DESCRIPTION
Django 1.7 issues below warning:
treebeard/mp_tree.py:102: RemovedInDjango18Warning:
`MP_NodeManager.get_query_set` method should be renamed `get_queryset`.

So the method get_query_set has been renamed to get_queryset to avoid
this warning.