### PR TITLE
Try fix the issue warning

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -102,7 +102,7 @@ class MP_NodeQuerySet(models.query.QuerySet):
 class MP_NodeManager(models.Manager):
     """Custom manager for nodes in a Materialized Path tree."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Sets the custom queryset as the default."""
         return MP_NodeQuerySet(self.model).order_by('path')
 


### PR DESCRIPTION
I tried fix the next warning:
```
/home/tulipan/Proyectos/ADKM/lib/python3.4/site-packages/treebeard/mp_tree.py:102: RemovedInDjango18Warning: `MP_NodeManager.get_query_set` method should be renamed `get_queryset`.
  class MP_NodeManager(models.Manager):
```