### PR TITLE
Fixed ImportError in `admin_tree` occurring in current Django `master` 

### DIFF
--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -12,7 +12,10 @@ from django.db import models
 from django.conf import settings
 from django.contrib.admin.templatetags.admin_list import (
     result_headers, result_hidden_fields)
-from django.contrib.admin.util import lookup_field, display_for_field
+try:
+    from django.contrib.admin.utils import lookup_field, display_for_field
+except ImportError:  # < Django 1.8
+    from django.contrib.admin.util import lookup_field, display_for_field
 from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
 from django.core.exceptions import ObjectDoesNotExist
 from django.template import Library


### PR DESCRIPTION
because `django.contrib.admin.util` became `django.contrib.admin.utils`