### PR TITLE
Compability with Django 1.10

### DIFF
--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -3,7 +3,7 @@
 import sys
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from django.contrib import admin, messages
 from django.http import HttpResponse, HttpResponseBadRequest


### PR DESCRIPTION
In Django 1.10 the patterns module has been removed (deprecated since 1.8)