### PR TITLE
Django 1.10 compatibility.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,25 +6,31 @@
 
 [tox]
 envlist =
-    py27-dj17-sqlite,
     py27-dj17-mysql,
     py27-dj17-pgsql,
-    py27-dj18-sqlite,
+    py27-dj17-sqlite,
     py27-dj18-mysql,
     py27-dj18-pgsql,
-    py27-dj19-sqlite,
+    py27-dj18-sqlite,
     py27-dj19-mysql,
     py27-dj19-pgsql,
-    py34-dj17-sqlite,
+    py27-dj19-sqlite,
+    py27-dj110-pgsql,
+    py27-dj110-sqlite,
     py34-dj17-pgsql,
-    py34-dj18-sqlite,
+    py34-dj17-sqlite,
     py34-dj18-pgsql,
-    py34-dj19-sqlite,
+    py34-dj18-sqlite,
     py34-dj19-pgsql,
-    py35-dj18-sqlite,
+    py34-dj19-sqlite,
+    py34-dj110-pgsql,
+    py34-dj110-sqlite,
     py35-dj18-pgsql,
-    py35-dj19-sqlite,
-    py35-dj19-pgsql
+    py35-dj18-sqlite,
+    py35-dj19-pgsql,
+    py35-dj19-sqlite
+    py35-dj110-pgsql,
+    py35-dj110-sqlite
 
 [testenv:docs]
 basepython=python
@@ -41,7 +47,8 @@ deps =
     pytest>2.7
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<2.0
+    dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<2.0
     mysql: MySQL-python>1.2
     pgsql: psycopg2>2.4.1
 setenv =

--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -3,7 +3,7 @@
 import sys
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from django.contrib import admin, messages
 from django.http import HttpResponse, HttpResponseBadRequest

--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -2,6 +2,8 @@
 
 import sys
 
+import django
+
 from django.conf import settings
 from django.conf.urls import url
 
@@ -44,8 +46,19 @@ class TreeAdmin(admin.ModelAdmin):
             self.change_list_template = 'admin/tree_list.html'
         if extra_context is None:
             extra_context = {}
-        lacks_request = ('request' not in extra_context and
-            'django.core.context_processors.request' not in settings.TEMPLATE_CONTEXT_PROCESSORS)
+        if django.VERSION < (1, 10):
+            request_context = 'django.core.context_processors.request' in settings.TEMPLATE_CONTEXT_PROCESSORS
+        else:
+            request_context = any(
+                map(
+                    lambda tmpl:
+                        tmpl.get('BACKEND', None) == 'django.template.backends.django.DjangoTemplates' and
+                        tmpl.get('APP_DIRS', False) and
+                        'django.template.context_processors.request' in tmpl.get('OPTIONS', {}).get('context_processors', []),
+                    settings.TEMPLATES
+                )
+            )
+        lacks_request = ('request' not in extra_context and not request_context)
         if lacks_request:
             extra_context['request'] = request
         return super(TreeAdmin, self).changelist_view(request, extra_context)

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -83,7 +83,7 @@ class MoveNodeForm(forms.ModelForm):
 
     def __init__(self, data=None, files=None, auto_id='id_%s', prefix=None,
                  initial=None, error_class=ErrorList, label_suffix=':',
-                 empty_permitted=False, instance=None):
+                 empty_permitted=False, instance=None, **kwargs):
         opts = self._meta
         if opts.model is None:
             raise ValueError('ModelForm has no model class specified')
@@ -113,7 +113,7 @@ class MoveNodeForm(forms.ModelForm):
 
         super(MoveNodeForm, self).__init__(
             data, files, auto_id, prefix, initial_, error_class, label_suffix, 
-            empty_permitted, instance)
+            empty_permitted, instance, **kwargs)
 
     def _clean_cleaned_data(self):
         """ delete auxilary fields not belonging to node model """

--- a/treebeard/templates/admin/tree_change_list_results.html
+++ b/treebeard/templates/admin/tree_change_list_results.html
@@ -1,4 +1,3 @@
-{% load cycle from future  %}
 {% if result_hidden_fields %}
     <div class="hiddenfields"> {# DIV for HTML validation #}
         {% for item in result_hidden_fields %}{{ item }}{% endfor %}

--- a/treebeard/tests/settings.py
+++ b/treebeard/tests/settings.py
@@ -89,3 +89,23 @@ MIDDLEWARE_CLASSES = [
 ]
 
 ROOT_URLCONF = 'treebeard.tests.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.template.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/treebeard/tests/urls.py
+++ b/treebeard/tests/urls.py
@@ -1,10 +1,8 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    # Uncomment the next line to enable the admin:
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-)
+]


### PR DESCRIPTION
This PR includes several changes to make django-treebeard compatible with Django
1.10 while maintaining compatibility with older versions back to 1.7:

 * Do not load templatetag  `cycle` from `future`.
 * Search request context processor in settings.TEMPLATES.
 * Add basic settings.TEMPLATES for tests.
 * Replace django.conf.urls.patterns with lists.
 * Add separate tox environments for Django 1.9 and 1.10.