### PR TITLE
django 1.10 adaptations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ setup_args = dict(
     package_dir={'treebeard': 'treebeard'},
     package_data={
         'treebeard': ['templates/admin/*.html', 'static/treebeard/*']},
-    description='Efficient tree implementations for Django 1.7+',
+    description='Efficient tree implementations for Django 1.10+',
     long_description=codecs.open(root_dir() + '/README.rst', encoding='utf-8').read(),
     cmdclass={'test': pytest_test},
-    install_requires=['Django>=1.7'],
+    install_requires=['Django>=1.10'],
     tests_require=['pytest'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This change set should have gone into https://github.com/tabo/django-treebeard/commit/2edb72dfef9a732b244056b392f7856691333f63
For me, otherwise `pip install` fails over with:
```bash
(nexchange) olegs-mbp:nexchange beoleg$ python manage.py migrate --settings=nexchange.settings_test
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
    utility.execute()
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/django/core/management/__init__.py", line 341, in execute
    django.setup()
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/django/apps/registry.py", line 115, in populate
    app_config.ready()
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/django/contrib/admin/apps.py", line 23, in ready
    self.module.autodiscover()
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/django/contrib/admin/__init__.py", line 26, in autodiscover
    autodiscover_modules('admin', register_to=site)
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/django/utils/module_loading.py", line 50, in autodiscover_modules
    import_module('%s.%s' % (app_config.name, module_to_search))
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/Users/beoleg/virtualenvs/nexchange/lib/python3.5/site-packages/treebeard/admin.py", line 6, in <module>
    from django.conf.urls import patterns, url
ImportError: cannot import name 'patterns'
```